### PR TITLE
use flycheck provided functions

### DIFF
--- a/helm-flycheck.el
+++ b/helm-flycheck.el
@@ -68,32 +68,23 @@ Inspect the *Messages* buffer for details.")
 
 (defun helm-flycheck-init ()
   "Initialize `helm-source-flycheck'."
-  (let ((status (helm-flycheck-status)))
-    (setq helm-flycheck-candidates
-          (if (helm-flycheck-has-errors-p status)
-              (mapcar 'helm-flycheck-make-candidate
-                      (flycheck-sort-errors flycheck-current-errors))
-            (list (helm-flycheck-status-message status))))))
+  (setq helm-flycheck-candidates
+        (if (flycheck-has-current-errors-p)
+            (mapcar 'helm-flycheck-make-candidate
+                    (flycheck-sort-errors flycheck-current-errors))
+          (list (helm-flycheck-status-message)))))
 
-(defun helm-flycheck-status ()
-  "Return `flycheck' status."
-  (flycheck-mode-line-status-text))
-
-(defun helm-flycheck-has-errors-p (status)
-  "Check whether the current buffer has `flycheck' errors with STATUS."
-  (equal ":" (ignore-errors (substring status 0 1))))
-
-(defun helm-flycheck-status-message (status)
+(defun helm-flycheck-status-message ()
   "Return message about `flycheck' STATUS."
-  (cond ((equal status "")
+  (cond ((equal flycheck-last-status-change 'finished)
          helm-flycheck-status-message-no-errors)
-        ((equal status "*")
+        ((equal flycheck-last-status-change 'running)
          helm-flycheck-status-message-syntax-checking)
-        ((equal status "-")
+        ((equal flycheck-last-status-change 'no-checker)
          helm-flycheck-status-message-checker-not-found)
-        ((equal status "!")
+        ((equal flycheck-last-status-change 'errored)
          helm-flycheck-status-message-failed)
-        ((equal status "?")
+        ((equal flycheck-last-status-change 'suspicious)
          helm-flycheck-status-message-dubious)))
 
 (defun helm-flycheck-make-candidate (error)


### PR DESCRIPTION
Hi,
I made some minor refactoring and code clean up, mostly using functions shipped in `flycheck` instead of `helm-flycheck-*` functions, as below:
1. Use `flycheck-has-current-errors-p` function instead of `helm-flycheck-has-errors-p`. Getting flycheck error status by parsing mode line message is flaky and gives false nagative results sometimes.
2. Use `flycheck-last-status-change` variable to determine `helm-flycheck-status-message-*`. In fact, flycheck uses this variable to set its mode line status too. See https://github.com/flycheck/flycheck/blob/master/flycheck.el#L3828. I think this change make sense as the value of this variable is more intuitive.

There might some points of the original design that I missed, therefore, feel free to let me know your thoughts and/or reject this PR.

Thanks,
