### PR TITLE
Support new flycheck

### DIFF
--- a/helm-flycheck.el
+++ b/helm-flycheck.el
@@ -97,11 +97,8 @@ Inspect the *Messages* buffer for details.")
                 flycheck-error-level
                 flycheck-error-level-error-list-face)))
     (format "%5s %3s%8s  %s"
-            (flycheck-error-list-make-number-cell
-             (flycheck-error-line error) 'flycheck-error-list-line-number)
-            (flycheck-error-list-make-number-cell
-             (flycheck-error-column error)
-             'flycheck-error-list-column-number)
+            (propertize (number-to-string (flycheck-error-line error)) 'font-lock-face 'flycheck-error-list-line-number)
+            (propertize (number-to-string (flycheck-error-column error)) 'font-lock-face 'flycheck-error-list-column-number)
             (propertize (symbol-name (flycheck-error-level error))
                         'font-lock-face face)
             (or (flycheck-error-message error) ""))))


### PR DESCRIPTION
I updated flycheck and helm-flycheck was broken.

Reason list
･ deleted function flycheck-sort-errors by [Drop redundant flycheck-sort-errors](https://github.com/flycheck/flycheck/commit/603ac4ef965868cc5c5bc75bdcc564605ee3cf43)
･ changed return value type by [Restore mouse support in error list](https://github.com/flycheck/flycheck/commit/5441d3d2d0703511310b389b83e347d97f4f20d5)

I write suppport patch.
