### PR TITLE
Emacs 24.3 have not "if-let"

### DIFF
--- a/helm-flycheck.el
+++ b/helm-flycheck.el
@@ -98,7 +98,7 @@ Inspect the *Messages* buffer for details.")
                 flycheck-error-level-error-list-face)))
     (format "%5s %3s%8s  %s"
             (propertize (number-to-string (flycheck-error-line error)) 'font-lock-face 'flycheck-error-list-line-number)
-            (if-let (column (flycheck-error-column error))
+            (-if-let (column (flycheck-error-column error))
                 (propertize (number-to-string column) 'font-lock-face 'flycheck-error-list-column-number) "")
             (propertize (symbol-name (flycheck-error-level error))
                         'font-lock-face face)


### PR DESCRIPTION
if-let is non release version macro.
It is trunk.
http://comments.gmane.org/gmane.emacs.diffs/125951

dash.el have -if-let macro.
helm-flycheck.el require dash.el already.
I suggest to use this macro.
